### PR TITLE
Removes scripts from background section of google V3 manifest file

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "mini-css-extract-plugin": "^0.11.3",
     "node-sass": "^7.0.0",
     "prettier": "^2.3.2",
+    "replace-in-file-webpack-plugin": "^1.0.6",
     "sass": "^1.39.0",
     "sass-loader": "^10.2.0",
     "style-loader": "^1.3.0",

--- a/webextension-toolbox.config.js
+++ b/webextension-toolbox.config.js
@@ -58,6 +58,19 @@ module.exports = {
         config.plugins.push(new VueLoaderPlugin());
         // config.plugins.push(new MiniCssExtractPlugin());
 
+        config.plugins.push(
+            new ReplaceInFileWebpackPlugin([{
+                dir: 'dist/chrome',
+                files: ['manifest.json'],
+                rules: [
+                    {
+                        search: /"scripts(.*)"service_worker"/sig,
+                        replace: '"service_worker"'
+                    }
+                ]
+            }])
+        )
+
         return config
     }
 };

--- a/webextension-toolbox.config.js
+++ b/webextension-toolbox.config.js
@@ -1,7 +1,7 @@
 // const webpack = require('webpack');
 const VueLoaderPlugin = require('vue-loader/lib/plugin');
 // const MiniCssExtractPlugin = require("mini-css-extract-plugin");
-
+const ReplaceInFileWebpackPlugin = require('replace-in-file-webpack-plugin');
 // console.log("webpack", webpack);
 
 module.exports = {


### PR DESCRIPTION
This is a small little update. 

It adds in 'replace in file webpack plugin' - which allows you to update & modify files after webpack has created them.

What this does - is finding the manifest file under dist/chrome - and remove the scripts section on the build so you don't have to do it manually during the development phase.

- Spike
