### PR TITLE
Fix to better align with Chrome's extension manifest v3 guide.

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -61,7 +61,7 @@
     "<all_urls>"
   ],
   "__chrome__commands": {
-    "_execute_browser_action": {
+    "_execute_action": {
       "suggested_key": { "default": "Ctrl+B", "mac": "Command+B" }
     }
   },


### PR DESCRIPTION
Fix to better align with Chrome's extension manifest v3 guide (https://developer.chrome.com/docs/extensions/reference/api/commands#action_commands).

- Chrome Manifest v3 no longer uses `_execute_browser_action`, and has replaced it with `_execute_action`.